### PR TITLE
rename updateManageWiki and split it into two functions

### DIFF
--- a/includes/RequestSSLManager.php
+++ b/includes/RequestSSLManager.php
@@ -367,6 +367,19 @@ class RequestSSLManager {
 	}
 
 	/**
+	 * @param User $user
+	 */
+	public function logToManageWiki( User $user ) {
+		$logEntry = new ManualLogEntry( 'managewiki', 'settings' );
+		$logEntry->setPerformer( $user );
+		$logEntry->setTarget( SpecialPage::getTitleValueFor( 'RequestSSLQueue', (string)$this->ID ) );
+		$logEntry->setComment( $this->messageLocalizer->msg( 'requestssl-managewiki-changedservername' ) );
+		$logEntry->setParameters( [ '4::wiki' => $this->getTarget(), '5::changes' => 'servername' ] );
+		$logID = $logEntry->insert();
+		$logEntry->publish( $logID );
+	}
+
+	/**
 	 * @param string $fname
 	 */
 	public function startAtomic( string $fname ) {
@@ -471,26 +484,18 @@ class RequestSSLManager {
 	}
 
 	/**
-	 * @param string $remotewiki
-	 * @param User $user
+	 * @return bool
 	 */
-	public function updateManageWiki( string $remotewiki, User $user ) {
+	public function updateServerName(): bool {
 		$newServerName = parse_url( $this->getCustomDomain(), PHP_URL_HOST );
 		if ( !$newServerName ) {
-			return;
+			return false;
 		}
 
 		$remoteWiki = new RemoteWiki( $this->getTarget() );
 		$remoteWiki->setServerName( 'https://' . $newServerName );
 		$remoteWiki->commit();
-
-		$logEntry = new ManualLogEntry( 'managewiki', 'settings' );
-		$logEntry->setPerformer( $user );
-		$logEntry->setTarget( SpecialPage::getTitleValueFor( 'RequestSSL' ) );
-		$logEntry->setComment( $this->messageLocalizer->msg( 'requestssl-managewiki-changedservername' ) );
-		$logEntry->setParameters( [ '4::wiki' => $this->getTarget(), '5::changes' => 'servername' ] );
-		$logID = $logEntry->insert();
-		$logEntry->publish( $logID );
+		return true;
 	}
 
 	/**

--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -3,6 +3,7 @@
 namespace Miraheze\RequestSSL;
 
 use Config;
+use ExtensionRegistry;
 use Html;
 use HTMLForm;
 use IContextSource;
@@ -559,7 +560,10 @@ class RequestSSLViewer {
 				->escaped();
 
 			if ( $oldStatus !== 'complete' && $formData['handle-status'] === 'complete' ) {
-				$this->requestSslRequestManager->updateManageWiki( $user, $this->context->getUser() );
+				$serverNameUpdated = $this->requestSslRequestManager->updateServerName();
+					if ( $serverNameUpdated && ExtensionRegistry::getInstance()->isLoaded( 'ManageWiki' ) ) {
+						$this->requestSslRequestManager->logToManageWiki( $this->context->getUser() );
+					}
 			}
 
 			if ( $formData['handle-comment'] ) {


### PR DESCRIPTION
Setting the servername and writing to the ManageWiki logs are two unrelated actions, therefore make it two different functions

Additionally, I cleaned up a bit.