### PR TITLE
Add phpcodesniffer-composer-installer to allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
 		"prepend-autoloader": false,
 		"optimize-autoloader": true,
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }


### PR DESCRIPTION
Required for mediawiki-codesniffer upgrade https://github.com/miraheze/RequestSSL/pull/28