### PR TITLE
Drop usage of UserRightsProxy

### DIFF
--- a/includes/RequestSSLManager.php
+++ b/includes/RequestSSLManager.php
@@ -19,7 +19,6 @@ use RepoGroup;
 use SpecialPage;
 use stdClass;
 use User;
-use UserRightsProxy;
 use Wikimedia\Rdbms\DBConnRef;
 use Wikimedia\Rdbms\ILBFactory;
 use Wikimedia\Rdbms\SelectQueryBuilder;
@@ -285,13 +284,9 @@ class RequestSSLManager {
 	 */
 	public function getUserGroupsFromTarget() {
 		$userName = $this->getRequester()->getName();
-		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
-			$remoteUser = $this->actorStoreFactory
-				->getUserIdentityLookup( $this->getTarget() )
-				->getUserIdentityByName( $userName );
-		} else {
-			$remoteUser = UserRightsProxy::newFromName( $this->getTarget(), $userName );
-		}
+		$remoteUser = $this->actorStoreFactory
+			->getUserIdentityLookup( $this->getTarget() )
+			->getUserIdentityByName( $userName );
 
 		if ( !$remoteUser ) {
 			return [ $this->messageLocalizer->msg( 'requestssl-usergroups-none' )->text() ];


### PR DESCRIPTION
Class is hard deprecated as of 1.41. RequestSSL also depends on CreateWiki, which has recently bumped minimum MW version to 1.41, so not any real point to trying to keep backwards compatibility here.