### PR TITLE
T11699: Create a job to automate CNAME checks

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -90,7 +90,7 @@
 			"services": [
 				"CreateWikiHookRunner",
 				"DBLoadBalancerFactory",
-				"JobQueueGroupFactory",
+				"JobQueueGroup",
 				"MimeAnalyzer",
 				"RepoGroup",
 				"UserFactory"

--- a/extension.json
+++ b/extension.json
@@ -38,6 +38,9 @@
 		"request-ssl",
 		"view-private-ssl-requests"
 	],
+	"JobClasses": {
+		"DomainCheckJob": "Miraheze\\RequestSSL\\DomainCheckJob"
+	},
 	"LogActionsHandlers": {
 		"requestssl/*": "LogFormatter",
 		"requestsslprivate/*": "LogFormatter"

--- a/extension.json
+++ b/extension.json
@@ -44,7 +44,8 @@
 			"services": [
 				"ConfigFactory",
 				"RequestSSLManager"
-			]
+			],
+			"needsPage": false
 		}
 	},
 	"LogActionsHandlers": {

--- a/extension.json
+++ b/extension.json
@@ -84,6 +84,7 @@
 			"services": [
 				"CreateWikiHookRunner",
 				"DBLoadBalancerFactory",
+				"JobQueueGroupFactory",
 				"MimeAnalyzer",
 				"RepoGroup",
 				"UserFactory"

--- a/extension.json
+++ b/extension.json
@@ -39,7 +39,13 @@
 		"view-private-ssl-requests"
 	],
 	"JobClasses": {
-		"DomainCheckJob": "Miraheze\\RequestSSL\\DomainCheckJob"
+		"DomainCheckJob": {
+			"class": "Miraheze\\RequestSSL\\Jobs\\DomainCheckJob",
+			"services": [
+				"ConfigFactory",
+				"RequestSSLManager"
+			]
+		}
 	},
 	"LogActionsHandlers": {
 		"requestssl/*": "LogFormatter",

--- a/extension.json
+++ b/extension.json
@@ -151,6 +151,10 @@
 			"value": "",
 			"description": "String. Specifies the CNAME record that RequestSSL will look for on automatic domain checks. If a domain has this CNAME record, it is considered to be pointed"
 		},
+		"RequestSSLDomainCheckReverseDNSRegex": {
+			"value": [],
+			"value": "String. If the automatic domain check returns A or AAAA records instead of a CNAME, check the reverse DNS of the IP address against this regex. The domain is considered pointed if there's a match"
+		},
 		"RequestSSLHelpUrl": {
 			"value": "",
 			"description": "Full URL. If set, adds a help URL to Special:RequestSSL."

--- a/extension.json
+++ b/extension.json
@@ -152,10 +152,6 @@
 			"value": "",
 			"description": "String. Specifies the CNAME record that RequestSSL will look for on automatic domain checks. If a domain has this CNAME record, it is considered to be pointed"
 		},
-		"RequestSSLDomainCheckReverseDNSRegex": {
-			"value": "",
-			"value": "String. If the automatic domain check returns A or AAAA records instead of a CNAME, check the reverse DNS of the IP address against this regex. The domain is considered pointed if there's a match"
-		},
 		"RequestSSLHelpUrl": {
 			"value": "",
 			"description": "Full URL. If set, adds a help URL to Special:RequestSSL."

--- a/extension.json
+++ b/extension.json
@@ -152,7 +152,7 @@
 			"description": "String. Specifies the CNAME record that RequestSSL will look for on automatic domain checks. If a domain has this CNAME record, it is considered to be pointed"
 		},
 		"RequestSSLDomainCheckReverseDNSRegex": {
-			"value": [],
+			"value": "",
 			"value": "String. If the automatic domain check returns A or AAAA records instead of a CNAME, check the reverse DNS of the IP address against this regex. The domain is considered pointed if there's a match"
 		},
 		"RequestSSLHelpUrl": {

--- a/extension.json
+++ b/extension.json
@@ -147,6 +147,10 @@
 			"value": "",
 			"description": "If set, only allow users to request a SSL certificate on this wiki."
 		},
+		"RequestSSLDomainCheckCNAME": {
+			"value": "",
+			"description": "String. Specifies the CNAME record that RequestSSL will look for on automatic domain checks. If a domain has this CNAME record, it is considered to be pointed"
+		},
 		"RequestSSLHelpUrl": {
 			"value": "",
 			"description": "Full URL. If set, adds a help URL to Special:RequestSSL."

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -2,7 +2,7 @@
 
 namespace Miraheze\RequestSSL;
 
-use GenericParameterJobM
+use GenericParameterJob;
 use Job;
 use MediaWiki\MediaWikiServices;
 

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -16,7 +16,7 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 		$requestSslManager = $mwServices->get( 'RequestSSLManager' );
 		$requestSslManager->fromID( $this->params['requestID'] );
 		$customDomain = parse_url( $requestSslManager->getCustomDomain(), PHP_URL_HOST );
-		if ( !customDomain ) {
+		if ( !$customDomain ) {
 			// Custom domain does not have a hostname, bail out.
 			// TODO: Log an exception.
 			return true;

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Miraheze\RequestSSL;
+
+use GenericParameterJobM
+use Job;
+use MediaWiki\MediaWikiServices;
+
+class DomainCheckJob extends Job implements GenericParameterJob {
+	public function __construct( array $params ) {
+		parent:__construct( 'DomainCheckJob', $params );
+	}
+	public function run()
+	$requestSslManager = MediaWikiServices::getInstance()->get( 'RequestSSLManager' );
+	$requestSslManager->fromID( $this->params['requestID'] );
+	// Do something useful
+}

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -21,7 +21,7 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 			return;
 		}
 		$config = $mwServices->getConfigFactory()->makeConfig('RequestSSL');
-		$cname = $config->get( 'RequestSSLDomainCheckCNAME' )
+		$cname = $config->get( 'RequestSSLDomainCheckCNAME' );
 		// TODO: Support rDNS and NS checks
 		// CNAME check
 		$dnsCNAMEData = dns_get_record( $customDomain, DNS_CNAME );

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -28,7 +28,7 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 		if ( !(bool)$dnsCNAMEData ) {
 			$requestSslManager->addComment( 'RequestSSL could not determine whether or not this domain is pointed: DNS returned no data during CNAME check.', User::newSystemUser( 'RequestSSL Extension' ) );
 		} else {
-			if ( $dnsCNAMEData['type'] === 'CNAME' && $dnsCNAMEData['target'] === $cname ) {
+			if ( $dnsCNAMEData[0]['type'] === 'CNAME' && $dnsCNAMEData[0]['target'] === $cname ) {
 				$requestSslManager->addComment( 'Domain is pointed via CNAME.', User::newSystemUser( 'RequestSSL Extension' ) );
 			} else {
 				$requestSslManager->addComment( 'Domain is not pointed via CNAME. It is possible it is pointed via other means.', User::newSystemUser( 'RequestSSL Extension' ) );

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -5,6 +5,7 @@ namespace Miraheze\RequestSSL;
 use GenericParameterJob;
 use Job;
 use MediaWiki\MediaWikiServices;
+use User;
 
 class DomainCheckJob extends Job implements GenericParameterJob {
 	public function __construct( array $params ) {
@@ -18,7 +19,7 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 		if ( !customDomain ) {
 			// Custom domain does not have a hostname, bail out.
 			// TODO: Log an exception.
-			return;
+			return true;
 		}
 		$config = $mwServices->getConfigFactory()->makeConfig('RequestSSL');
 		$cname = $config->get( 'RequestSSLDomainCheckCNAME' );
@@ -34,5 +35,6 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 				$requestSslManager->addComment( 'Domain is not pointed via CNAME. It is possible it is pointed via other means.', User::newSystemUser( 'RequestSSL Extension' ) );
 			}
 		}
+		return true;
 	}
 }

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -9,7 +9,7 @@ use User;
 
 class DomainCheckJob extends Job implements GenericParameterJob {
 	public function __construct( array $params ) {
-		parent:__construct( 'DomainCheckJob', $params );
+		parent::__construct( 'DomainCheckJob', $params );
 	}
 	public function run() {
 		$mwServices = MediaWikiServices::getInstance();

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -26,7 +26,7 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 		// TODO: Support rDNS and NS checks
 		// CNAME check
 		$dnsCNAMEData = dns_get_record( $customDomain, DNS_CNAME );
-		if ( !(bool)$dnsCNAMEData ) {
+		if ( !$dnsCNAMEData ) {
 			$requestSslManager->addComment( 'RequestSSL could not determine whether or not this domain is pointed: DNS returned no data during CNAME check.', User::newSystemUser( 'RequestSSL Extension' ) );
 		} else {
 			if ( $dnsCNAMEData[0]['type'] === 'CNAME' && $dnsCNAMEData[0]['target'] === $cname ) {

--- a/includes/DomainCheckJob.php
+++ b/includes/DomainCheckJob.php
@@ -10,8 +10,9 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 	public function __construct( array $params ) {
 		parent:__construct( 'DomainCheckJob', $params );
 	}
-	public function run()
-	$requestSslManager = MediaWikiServices::getInstance()->get( 'RequestSSLManager' );
-	$requestSslManager->fromID( $this->params['requestID'] );
-	// Do something useful
+	public function run() {
+		$requestSslManager = MediaWikiServices::getInstance()->get( 'RequestSSLManager' );
+		$requestSslManager->fromID( $this->params['requestID'] );
+		// Do something useful
+	}
 }

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -2,37 +2,62 @@
 
 namespace Miraheze\RequestSSL\Jobs;
 
+use Config;
+use ConfigFactory;
 use GenericParameterJob;
 use Job;
-use MediaWiki\MediaWikiServices;
+use Miraheze\RequestSSL\RequestSSLManager;
 use User;
 
 class DomainCheckJob extends Job implements GenericParameterJob {
-	public function __construct( array $params ) {
+
+	/** @var Config */
+	private $config;
+
+	/** @var int */
+	private $requestID;
+
+	/** @var RequestSSLManager */
+	private $requestSslManager;
+
+	/**
+	 * @param array $params
+	 * @param ConfigFactory $configFactory
+	 * @param RequestSSLManager $requestSslManager
+	*/
+	public function __construct(
+		array $params,
+		ConfigFactory $configFactory,
+		RequestSSLManager $requestSslManager
+	) {
 		parent::__construct( 'DomainCheckJob', $params );
+		$this->requestID = $params['requestID'];
+		$this->config = $configFactory->makeConfig( 'RequestSSL' );
+		$this->requestSslManager = $requestSslManager;
 	}
+
+	/**
+	 * @return bool
+	 */
 	public function run() {
-		$mwServices = MediaWikiServices::getInstance();
-		$requestSslManager = $mwServices->get( 'RequestSSLManager' );
-		$requestSslManager->fromID( $this->params['requestID'] );
-		$customDomain = parse_url( $requestSslManager->getCustomDomain(), PHP_URL_HOST );
+		$this->requestSslManager->fromID( $this->requestID );
+		$customDomain = parse_url( $this->requestSslManager->getCustomDomain(), PHP_URL_HOST );
 		if ( !$customDomain ) {
 			// Custom domain does not have a hostname, bail out.
 			// TODO: Log an exception.
 			return true;
 		}
-		$config = $mwServices->getConfigFactory()->makeConfig('RequestSSL');
-		$cname = $config->get( 'RequestSSLDomainCheckCNAME' );
+		$cname = $this->config->get( 'RequestSSLDomainCheckCNAME' );
 		// TODO: Support rDNS and NS checks
 		// CNAME check
 		$dnsCNAMEData = dns_get_record( $customDomain, DNS_CNAME );
 		if ( !$dnsCNAMEData ) {
-			$requestSslManager->addComment( 'RequestSSL could not determine whether or not this domain is pointed: DNS returned no data during CNAME check.', User::newSystemUser( 'RequestSSL Extension' ) );
+			$this->requestSslManager->addComment( 'RequestSSL could not determine whether or not this domain is pointed: DNS returned no data during CNAME check.', User::newSystemUser( 'RequestSSL Extension' ) );
 		} else {
 			if ( $dnsCNAMEData[0]['type'] === 'CNAME' && $dnsCNAMEData[0]['target'] === $cname ) {
-				$requestSslManager->addComment( 'Domain is pointed via CNAME.', User::newSystemUser( 'RequestSSL Extension' ) );
+				$this->requestSslManager->addComment( 'Domain is pointed via CNAME.', User::newSystemUser( 'RequestSSL Extension' ) );
 			} else {
-				$requestSslManager->addComment( 'Domain is not pointed via CNAME. It is possible it is pointed via other means.', User::newSystemUser( 'RequestSSL Extension' ) );
+				$this->requestSslManager->addComment( 'Domain is not pointed via CNAME. It is possible it is pointed via other means.', User::newSystemUser( 'RequestSSL Extension' ) );
 			}
 		}
 		return true;

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Miraheze\RequestSSL;
+namespace Miraheze\RequestSSL\Jobs;
 
 use GenericParameterJob;
 use Job;

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -7,7 +7,7 @@ use ConfigFactory;
 use GenericParameterJob;
 use Job;
 use Miraheze\RequestSSL\RequestSSLManager;
-use User;
+use MediaWiki\User\User;
 
 class DomainCheckJob extends Job implements GenericParameterJob {
 

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -8,7 +8,7 @@ use GenericParameterJob;
 use Job;
 use Miraheze\RequestSSL\RequestSSLManager;
 use MediaWiki\User\User;
-use Title
+use Title;
 
 class DomainCheckJob extends Job implements GenericParameterJob {
 

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -8,6 +8,7 @@ use GenericParameterJob;
 use Job;
 use Miraheze\RequestSSL\RequestSSLManager;
 use MediaWiki\User\User;
+use Title
 
 class DomainCheckJob extends Job implements GenericParameterJob {
 
@@ -21,11 +22,13 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 	private $requestSslManager;
 
 	/**
+	 * @param Title $title
 	 * @param array $params
 	 * @param ConfigFactory $configFactory
 	 * @param RequestSSLManager $requestSslManager
 	*/
 	public function __construct(
+		Title $title,
 		array $params,
 		ConfigFactory $configFactory,
 		RequestSSLManager $requestSslManager

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -44,7 +44,7 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 		$customDomain = parse_url( $this->requestSslManager->getCustomDomain(), PHP_URL_HOST );
 		if ( !$customDomain ) {
 			// Custom domain does not have a hostname, bail out.
-			// TODO: Log an exception.
+			$this->setLastError( 'Custom domain does not have a hostname.' );
 			return true;
 		}
 		$cname = $this->config->get( 'RequestSSLDomainCheckCNAME' );

--- a/includes/Jobs/DomainCheckJob.php
+++ b/includes/Jobs/DomainCheckJob.php
@@ -8,7 +8,6 @@ use GenericParameterJob;
 use Job;
 use Miraheze\RequestSSL\RequestSSLManager;
 use MediaWiki\User\User;
-use Title;
 
 class DomainCheckJob extends Job implements GenericParameterJob {
 
@@ -22,13 +21,11 @@ class DomainCheckJob extends Job implements GenericParameterJob {
 	private $requestSslManager;
 
 	/**
-	 * @param Title $title
 	 * @param array $params
 	 * @param ConfigFactory $configFactory
 	 * @param RequestSSLManager $requestSslManager
 	*/
 	public function __construct(
-		Title $title,
 		array $params,
 		ConfigFactory $configFactory,
 		RequestSSLManager $requestSslManager

--- a/includes/Specials/SpecialRequestSSL.php
+++ b/includes/Specials/SpecialRequestSSL.php
@@ -14,7 +14,7 @@ use Message;
 use MimeAnalyzer;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\RemoteWiki;
-use Miraheze\RequestSSL\DomainCheckJob;
+use Miraheze\RequestSSL\Jobs\DomainCheckJob;
 use RepoGroup;
 use SpecialPage;
 use Status;

--- a/includes/Specials/SpecialRequestSSL.php
+++ b/includes/Specials/SpecialRequestSSL.php
@@ -9,7 +9,7 @@ use FormSpecialPage;
 use Html;
 use JobSpecification;
 use ManualLogEntry;
-use MediaWiki\JobQueue\JobQueueGroup;
+use JobQueueGroup;
 use MediaWiki\User\UserFactory;
 use Message;
 use MimeAnalyzer;

--- a/includes/Specials/SpecialRequestSSL.php
+++ b/includes/Specials/SpecialRequestSSL.php
@@ -9,7 +9,7 @@ use FormSpecialPage;
 use Html;
 use JobSpecification;
 use ManualLogEntry;
-use MediaWiki\JobQueue\JobQueueGroupFactory;
+use MediaWiki\JobQueue\JobQueueGroup;
 use MediaWiki\User\UserFactory;
 use Message;
 use MimeAnalyzer;
@@ -32,8 +32,8 @@ class SpecialRequestSSL extends FormSpecialPage {
 	/** @var ILBFactory */
 	private $dbLoadBalancerFactory;
 
-	/** @var JobQueueGroupFactory */
-	private $jobQueueGroupFactory;
+	/** @var JobQueueGroup */
+	private $jobQueueGroup;
 
 	/** @var MimeAnalyzer */
 	private $mimeAnalyzer;
@@ -47,7 +47,7 @@ class SpecialRequestSSL extends FormSpecialPage {
 	/**
 	 * @param CreateWikiHookRunner $createWikiHookRunner
 	 * @param ILBFactory $dbLoadBalancerFactory
-	 * @param JobQueueGroupFactory $jobQueueGroupFactory
+	 * @param JobQueueGroup $jobQueueGroupFactory
 	 * @param MimeAnalyzer $mimeAnalyzer
 	 * @param RepoGroup $repoGroup
 	 * @param UserFactory $userFactory
@@ -55,7 +55,7 @@ class SpecialRequestSSL extends FormSpecialPage {
 	public function __construct(
 		CreateWikiHookRunner $createWikiHookRunner,
 		ILBFactory $dbLoadBalancerFactory,
-		JobQueueGroupFactory $jobQueueGroupFactory,
+		JobQueueGroup $jobQueueGroup,
 		MimeAnalyzer $mimeAnalyzer,
 		RepoGroup $repoGroup,
 		UserFactory $userFactory
@@ -64,7 +64,7 @@ class SpecialRequestSSL extends FormSpecialPage {
 
 		$this->createWikiHookRunner = $createWikiHookRunner;
 		$this->dbLoadBalancerFactory = $dbLoadBalancerFactory;
-		$this->jobQueueGroupFactory = $jobQueueGroupFactory;
+		$this->jobQueueGroup = $jobQueueGroup;
 		$this->mimeAnalyzer = $mimeAnalyzer;
 		$this->repoGroup = $repoGroup;
 		$this->userFactory = $userFactory;
@@ -231,8 +231,7 @@ class SpecialRequestSSL extends FormSpecialPage {
 		}
 
 		$domainCheckJob = new JobSpecification( 'DomainCheckJob', ['requestID' => $requestID] );
-		$jobQueueGroup = $this->jobQueueGroupFactory->makeJobQueueGroup();
-		$jobQueueGroup->lazyPush( $domainCheckJob );
+		$this->jobQueueGroup->lazyPush( $domainCheckJob );
 
 		return Status::newGood();
 	}

--- a/includes/Specials/SpecialRequestSSL.php
+++ b/includes/Specials/SpecialRequestSSL.php
@@ -230,8 +230,9 @@ class SpecialRequestSSL extends FormSpecialPage {
 			$this->sendNotifications( $data['reason'], $this->getUser()->getName(), $requestID, $data['target'] );
 		}
 
-		$domainCheckJob = new DomainCheckJob( ['requestID' => $requestID] )
-		$this->jobQueueGroup->lazyPush( $domainCheckJob );
+		$domainCheckJob = new DomainCheckJob( ['requestID' => $requestID] );
+		$jobQueueGroup = $this->jobQueueGroupFactory->makeJobQueueGroup();
+		$jobQueueGroup->lazyPush( $domainCheckJob );
 
 		return Status::newGood();
 	}

--- a/includes/Specials/SpecialRequestSSL.php
+++ b/includes/Specials/SpecialRequestSSL.php
@@ -47,7 +47,7 @@ class SpecialRequestSSL extends FormSpecialPage {
 	/**
 	 * @param CreateWikiHookRunner $createWikiHookRunner
 	 * @param ILBFactory $dbLoadBalancerFactory
-	 * @param JobQueueGroup $jobQueueGroupFactory
+	 * @param JobQueueGroup $jobQueueGroup
 	 * @param MimeAnalyzer $mimeAnalyzer
 	 * @param RepoGroup $repoGroup
 	 * @param UserFactory $userFactory

--- a/includes/Specials/SpecialRequestSSL.php
+++ b/includes/Specials/SpecialRequestSSL.php
@@ -7,6 +7,7 @@ use ErrorPageError;
 use ExtensionRegistry;
 use FormSpecialPage;
 use Html;
+use JobSpecification;
 use ManualLogEntry;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
 use MediaWiki\User\UserFactory;
@@ -14,7 +15,6 @@ use Message;
 use MimeAnalyzer;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\RemoteWiki;
-use Miraheze\RequestSSL\Jobs\DomainCheckJob;
 use RepoGroup;
 use SpecialPage;
 use Status;
@@ -230,7 +230,7 @@ class SpecialRequestSSL extends FormSpecialPage {
 			$this->sendNotifications( $data['reason'], $this->getUser()->getName(), $requestID, $data['target'] );
 		}
 
-		$domainCheckJob = new DomainCheckJob( ['requestID' => $requestID] );
+		$domainCheckJob = new JobSpecification( 'DomainCheckJob', ['requestID' => $requestID] );
 		$jobQueueGroup = $this->jobQueueGroupFactory->makeJobQueueGroup();
 		$jobQueueGroup->lazyPush( $domainCheckJob );
 


### PR DESCRIPTION
This PR does part of T11699. It introduces a job that is queued automatically when requests are created, and it automatically checks that the custom domain requested has the correct CNAME record.

https://issue-tracker.miraheze.org/T11699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated domain checking functionality.
  - Added configuration for specifying CNAME records for domain checks.

- **Improvements**
  - Enhanced domain verification process to ensure custom domains are correctly pointed.

- **Backend Enhancements**
  - Integrated job queue management for handling domain check tasks efficiently.

These updates aim to streamline domain management and enhance reliability in domain verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->