### PR TITLE
Prevent setting $this->mDb twice

### DIFF
--- a/includes/RequestSSLQueuePager.php
+++ b/includes/RequestSSLQueuePager.php
@@ -47,9 +47,9 @@ class RequestSSLQueuePager extends TablePager {
 		string $status,
 		string $target
 	) {
-		parent::__construct( $context, $linkRenderer );
-
 		$this->mDb = $connectionProvider->getReplicaDatabase( 'virtual-requestssl' );
+
+		parent::__construct( $context, $linkRenderer );
 
 		$this->linkRenderer = $linkRenderer;
 		$this->userFactory = $userFactory;


### PR DESCRIPTION
We set $this->mDb before calling parent::