### PR TITLE
Use OOUI messagewidget inside of HTMLForm rather then Html::(warning/error/success/notice)Box

### DIFF
--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -223,7 +223,7 @@ class RequestSSLViewer {
 
 				$fileInfo .= Html::element( 'button', [
 						'type' => 'button',
-						'onclick' => 'navigator.clipboard.writeText( $( \'.mw-message-box-notice code\' ).text() );',
+						'onclick' => 'navigator.clipboard.writeText( $( \'.oo-ui-flaggedElement-notice code\' ).text() );',
 					],
 					$this->context->msg( 'requestssl-button-copy' )->text()
 				);

--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -223,7 +223,8 @@ class RequestSSLViewer {
 
 				$fileInfo .= Html::element( 'button', [
 						'type' => 'button',
-						'onclick' => 'navigator.clipboard.writeText( $( \'.oo-ui-flaggedElement-notice code\' ).text() );',
+						'onclick' => 'navigator.clipboard.writeText( 
+      								$( \'.oo-ui-flaggedElement-notice code\' ).text() );',
 					],
 					$this->context->msg( 'requestssl-button-copy' )->text()
 				);

--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -10,6 +10,8 @@ use IContextSource;
 use Linker;
 use MediaWiki\Permissions\PermissionManager;
 use Message;
+use OOUI\HtmlSnippet;
+use OOUI\MessageWidget;
 use User;
 use UserNotLoggedIn;
 use WikiMap;
@@ -83,6 +85,8 @@ class RequestSSLViewer {
 				)
 			);
 		}
+
+		$this->context->getOutput()->enableOOUI();
 
 		$formDescriptor = [
 			'customdomain' => [
@@ -223,41 +227,53 @@ class RequestSSLViewer {
 					],
 					$this->context->msg( 'requestssl-button-copy' )->text()
 				);
-				$info = Html::noticeBox( $fileInfo, '' );
+				$info = new MessageWidget( [
+					'label' => new HtmlSnippet($fileInfo),
+					'type' => 'notice',
+				] );
 
-			$info .= Html::noticeBox(
-				$this->context->msg( 'requestssl-info-groups',
-					$this->requestSslRequestManager->getRequester()->getName(),
-					$this->requestSslRequestManager->getTarget(),
-					$this->context->getLanguage()->commaList(
-						$this->requestSslRequestManager->getUserGroupsFromTarget()
-					)
-				)->escaped(),
-				''
-			);
+			$info .= new MessageWidget(
+				'label' => new HtmlSnippet(
+						$this->context->msg( 'requestssl-info-groups',
+							$this->requestSslRequestManager->getRequester()->getName(),
+							$this->requestSslRequestManager->getTarget(),
+							$this->context->getLanguage()->commaList(
+								$this->requestSslRequestManager->getUserGroupsFromTarget()
+							)
+						)->escaped(),
+					),
+				'type' => 'notice',
+			] );
 
 			if ( $this->requestSslRequestManager->isPrivate() ) {
-				$info .= Html::warningBox(
-					$this->context->msg( 'requestssl-info-request-private' )->escaped()
-				);
+				$info .= new MessageWidget( [
+					'label' => new HtmlSnippet($this->context->msg( 'requestssl-info-request-private' )->escaped()),
+					'type' => 'warning'.
+				] );
 			}
 
 			if ( $this->requestSslRequestManager->getRequester()->getBlock() ) {
-				$info .= Html::warningBox(
-					$this->context->msg( 'requestssl-info-requester-locally-blocked',
-						$this->requestSslRequestManager->getRequester()->getName(),
-						WikiMap::getCurrentWikiId()
-					)->escaped()
-				);
+				$info .= new MessageWidget( [
+					'label' => new HtmlSnippet(
+							$this->context->msg( 'requestssl-info-requester-locally-blocked',
+								$this->requestSslRequestManager->getRequester()->getName(),
+								WikiMap::getCurrentWikiId()
+							)->escaped()
+						),
+					'type' => 'warning',
+				] );
 			}
 
 			// @phan-suppress-next-line PhanDeprecatedFunction Only for MW 1.39 or lower.
 			if ( $this->requestSslRequestManager->getRequester()->getGlobalBlock() ) {
-				$info .= Html::errorBox(
-					$this->context->msg( 'requestssl-info-requester-globally-blocked',
-						$this->requestSslRequestManager->getRequester()->getName()
-					)->escaped()
-				);
+				$info .= new MessageWidget( [
+					'label' => new HtmlSnippet(
+								$this->context->msg( 'requestssl-info-requester-globally-blocked',
+								$this->requestSslRequestManager->getRequester()->getName()
+							)->escaped()
+						),
+					'type' => 'error',
+				] );
 
 				$validRequest = false;
 				if ( $status === 'pending' || $status === 'inprogress' ) {
@@ -266,11 +282,14 @@ class RequestSSLViewer {
 			}
 
 			if ( $this->requestSslRequestManager->getRequester()->isLocked() ) {
-				$info .= Html::errorBox(
-					$this->context->msg( 'requestssl-info-requester-locked',
-						$this->requestSslRequestManager->getRequester()->getName()
-					)->escaped()
-				);
+				$info .= new MessageWidget( [
+					'label' => new HtmlSnippet(
+								$this->context->msg( 'requestssl-info-requester-locked',
+								$this->requestSslRequestManager->getRequester()->getName()
+							)->escaped()
+						),
+					'type' => 'error',
+				] );
 
 				$validRequest = false;
 				if ( $status === 'pending' || $status === 'inprogress' ) {

--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -248,7 +248,7 @@ class RequestSSLViewer {
 			if ( $this->requestSslRequestManager->isPrivate() ) {
 				$info .= new MessageWidget( [
 					'label' => new HtmlSnippet($this->context->msg( 'requestssl-info-request-private' )->escaped()),
-					'type' => 'warning'.
+					'type' => 'warning',
 				] );
 			}
 

--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -232,7 +232,7 @@ class RequestSSLViewer {
 					'type' => 'notice',
 				] );
 
-			$info .= new MessageWidget(
+			$info .= new MessageWidget( [
 				'label' => new HtmlSnippet(
 						$this->context->msg( 'requestssl-info-groups',
 							$this->requestSslRequestManager->getRequester()->getName(),

--- a/includes/RequestSSLViewer.php
+++ b/includes/RequestSSLViewer.php
@@ -228,7 +228,7 @@ class RequestSSLViewer {
 					$this->context->msg( 'requestssl-button-copy' )->text()
 				);
 				$info = new MessageWidget( [
-					'label' => new HtmlSnippet($fileInfo),
+					'label' => new HtmlSnippet( $fileInfo ),
 					'type' => 'notice',
 				] );
 
@@ -247,7 +247,7 @@ class RequestSSLViewer {
 
 			if ( $this->requestSslRequestManager->isPrivate() ) {
 				$info .= new MessageWidget( [
-					'label' => new HtmlSnippet($this->context->msg( 'requestssl-info-request-private' )->escaped()),
+					'label' => new HtmlSnippet( $this->context->msg( 'requestssl-info-request-private' )->escaped() ),
 					'type' => 'warning',
 				] );
 			}

--- a/modules/ext.requestssl.oouiform.ooui.less
+++ b/modules/ext.requestssl.oouiform.ooui.less
@@ -1,7 +1,7 @@
 #requestssl {
 	filter: brightness( 1 );
 
-	.mw-message-box-notice {
+	.oo-ui-flaggedElement-notice {
 		border-color: #33a6f1;
 		background: #bce5fd;
 


### PR DESCRIPTION
T13184

Html::(warning/error/success/notice)Box (part of Codex) seems not to work reliably inside of the OOUI based HTMLForm therefore we switch it to the OOUI version which is MessageWidget(type: (warning/error/success/notice))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the presentation of notifications and warnings, offering a modern and consistent user interface.
	- Upgraded message displays to improve the overall clarity and structure of user information using OOUI components.
- **Style**
	- Updated CSS class for message box styling to align with OOUI design standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->